### PR TITLE
Logs: Add CSV Logger, modify logging from 4 GPUs to logging all-reduc…

### DIFF
--- a/scripts/bash_slurm/script_experiments.sh
+++ b/scripts/bash_slurm/script_experiments.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-rm output.txt
 
 # create the required directory for data storage on the temporary but super fast file tmpfs filesystem
 mkdir -p /dev/shm/hai_nasb_eo/data
@@ -7,17 +6,10 @@ mkdir -p /dev/shm/hai_nasb_eo/data
 # Copy the data to the target storage directory
 cp /p/project/hai_nasb_eo/data/*h5 /dev/shm/hai_nasb_eo/data
 
-# Load the modules and libraries for the experiments
-#module load Stages/2020  GCCcore/.9.3.0 Singularity-Tools/2020-Python-3.7.9
-
 # Run the container with support for nvidia and cuda
-# apptainer exec --nv /p/project/hai_automleo/utils_hpo_pop_est/docker_images/hpo_pop_estimation_version1.sif bash mini_script_local_commands.sh
-#!!!!! we will add our container trigger here.
 module load Stages/2022  Apptainer-Tools/2022 GCCcore/.9.3.0
 
 #apptainer pull docker://dockiron/mdsi2022-automl-torch1.9:latest
 # `--nv` option enables nvidia support.
 # apptainer run --nv mdsi2022-automl-torch1.9_latest.sif
 apptainer exec --nv mdsi2022-automl-torch1.9_latest.sif python3 ./scripts/training_torchlightning.py --arch $1
-
-#cd emre/tum-dlr-automl-for-eo/sr

--- a/scripts/bash_slurm/slurm_job.sh
+++ b/scripts/bash_slurm/slurm_job.sh
@@ -1,21 +1,18 @@
 #!/bin/bash -x
 
 #SBATCH --account=hai_nasb_eo
-#SBATCH --partition=booster # number of gpus per node
+#SBATCH --partition=develbooster # booster or develbooster number of gpus per node
 #SBATCH --gres=gpu:4   
 #SBATCH --job-name=torch-test   
 #SBATCH --nodes=1                # node count
 #SBATCH --ntasks=1               # total number of tasks across all nodes
 #SBATCH --cpus-per-task=1        # cpu-cores per task (>1 if multi-threaded tasks)   
-#SBATCH --time=04:00:00          # total run time limit (HH:MM:SS)
+#SBATCH --time=01:00:00          # total run time limit (HH:MM:SS)
 #SBATCH --output=gpu-out.%j
 #SBATCH --error=gpu-err.%j
-
-#6426898
-#6426898
 
 # go to the repository directory                                                                                                                                                                                   
 cd /p/project/hai_nasb_eo/emre/tum-dlr-automl-for-eo/
 
 # connect interactively to the compute node for experiments
-srun /p/project/hai_nasb_eo/emre/tum-dlr-automl-for-eo/scripts/bash_slurm/script_experiments.sh /p/project/hai_nasb_eo/emre/tum-dlr-automl-for-eo/scripts/architectures/arch_2
+srun /p/project/hai_nasb_eo/emre/tum-dlr-automl-for-eo/scripts/bash_slurm/script_experiments.sh ${1}

--- a/src/tum_dlr_automl_for_eo/utils/helper_functions.py
+++ b/src/tum_dlr_automl_for_eo/utils/helper_functions.py
@@ -7,6 +7,7 @@ Following functions have been modified from https://github.com/kalifou/fitness_l
 """
 from naslib.utils import nb101_api as api
 import pyDOE
+import numpy as np
 
 # Useful constants
 


### PR DESCRIPTION
1. Modify to log the aggregated values only (all_reduced value in 4 GPU each iteration/epoch) - the old version logs each GPU separately
2. Remove the validation_epoch_end() function because they are redundant, Trainer logger can already take care of the average value for us
3. Add CSVLogger along with TF logs just for debugging
4. Add console logging after aggregating the results
5. Add the JSON file at the end to store some static values like trainable_params, learning rate, weight decay, etc.

Please check if I have handled the result_path correctly to store the resulted architectures